### PR TITLE
update templates to use new protobuf api

### DIFF
--- a/microweb.go
+++ b/microweb.go
@@ -150,7 +150,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/protobuf/encoding/protojson"
 	"github.com/go-chi/render"
 	"github.com/go-chi/chi"
 	{{ range $imports }}
@@ -240,13 +240,13 @@ func Register{{ .Name }}Web(r chi.Router, i {{ .Name }}Handler, middlewares ...f
 
 {{ range .AllMessages }}
 
-// {{ marshaler . }} describes the default jsonpb.Marshaler used by all
+// {{ marshaler . }} describes the default protojson.Marshaler used by all
 // instances of {{ name . }}. This struct is safe to replace or modify but
 // should not be done so concurrently.
-var {{ marshaler . }} = new(jsonpb.Marshaler)
+var {{ marshaler . }} = new(protojson.Marshaler)
 
 // MarshalJSON satisfies the encoding/json Marshaler interface. This method
-// uses the more correct jsonpb package to correctly marshal the message.
+// uses the more correct protojson package to correctly marshal the message.
 func (m *{{ name . }}) MarshalJSON() ([]byte, error) {
 	if m == nil {
 		return json.Marshal(nil)
@@ -263,13 +263,13 @@ func (m *{{ name . }}) MarshalJSON() ([]byte, error) {
 
 var _ json.Marshaler = (*{{ name . }})(nil)
 
-// {{ unmarshaler . }} describes the default jsonpb.Unmarshaler used by all
+// {{ unmarshaler . }} describes the default protojson.Unmarshaler used by all
 // instances of {{ name . }}. This struct is safe to replace or modify but
 // should not be done so concurrently.
-var {{ unmarshaler . }} = new(jsonpb.Unmarshaler)
+var {{ unmarshaler . }} = new(protojson.Unmarshaler)
 
 // UnmarshalJSON satisfies the encoding/json Unmarshaler interface. This method
-// uses the more correct jsonpb package to correctly unmarshal the message.
+// uses the more correct protojson package to correctly unmarshal the message.
 func (m *{{ name . }}) UnmarshalJSON(b []byte) error {
 	return {{ unmarshaler . }}.Unmarshal(bytes.NewReader(b), m)
 }


### PR DESCRIPTION
Google introduced a new protobuf API: https://blog.golang.org/protobuf-apiv2 causing the current release of staticckeck to barf on several related packages: https://github.com/dominikh/go-tools/issues/732 ... fixed in https://github.com/dominikh/go-tools/commit/7e758a3887f90d0ded5f0446112616758183866b

Currently, protoc-gen-microweb uses `github.com/golang/protobuf/jsonpb` which is still reported:
```
make staticcheck
go run honnef.co/go/tools/cmd/staticcheck -tags '' github.com/owncloud/ocis-hello/cmd/ocis-hello github.com/owncloud/ocis-hello/pkg/assets github.com/owncloud/ocis-hello/pkg/command github.com/owncloud/ocis-hello/pkg/config github.com/owncloud/ocis-hello/pkg/flagset github.com/owncloud/ocis-hello/pkg/metrics github.com/owncloud/ocis-hello/pkg/proto/v0 github.com/owncloud/ocis-hello/pkg/server/debug github.com/owncloud/ocis-hello/pkg/server/grpc github.com/owncloud/ocis-hello/pkg/server/http github.com/owncloud/ocis-hello/pkg/service/v0 github.com/owncloud/ocis-hello/pkg/version
pkg/proto/v0/hello.pb.micro.go:8:2: package github.com/golang/protobuf/proto is deprecated: Use the "google.golang.org/protobuf/proto" package instead.  (SA1019)
pkg/proto/v0/hello.pb.web.go:14:2: package github.com/golang/protobuf/jsonpb is deprecated: Use the "google.golang.org/protobuf/encoding/protojson" package instead.  (SA1019)
exit status 1
make: *** [Makefile:73: staticcheck] Fehler 1
```

This PR should update the dependency.